### PR TITLE
Avoid "float" positioning to fix pin

### DIFF
--- a/BlazorWeather.Core/wwwroot/css/weather.css
+++ b/BlazorWeather.Core/wwwroot/css/weather.css
@@ -283,14 +283,19 @@ h3 {
     transform: none;
 }
 
+.pinnable-location {
+    position: relative;
+}
+
 .pinnable-location h1 {
     display: inline-block;
 }
 
 .pinnable-location .pushpin-container {
-    vertical-align: middle;
-    float: right;
-    margin-top: 5px;  
+    position: absolute;
+    top: 0.4rem;
+    left: 100%;
+    margin-left: 0.5rem;
 }
 
 .current-location {

--- a/BlazorWeather.Electron/wwwroot/_content/BlazorWeather.Core/css/weather.css
+++ b/BlazorWeather.Electron/wwwroot/_content/BlazorWeather.Core/css/weather.css
@@ -283,14 +283,19 @@ h3 {
     transform: none;
 }
 
+.pinnable-location {
+    position: relative;
+}
+
 .pinnable-location h1 {
     display: inline-block;
 }
 
 .pinnable-location .pushpin-container {
-    vertical-align: middle;
-    float: right;
-    margin-top: 5px;  
+    position: absolute;
+    top: 0.4rem;
+    left: 100%;
+    margin-left: 0.5rem;
 }
 
 .current-location {


### PR DESCRIPTION
The CSS was using `float: right` which is notoriously quirky. Flexbox would be better, but in this case relative+absolute positioning is sufficient.